### PR TITLE
refactor(player): stop shouldn't set isConnected to off

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -88,7 +88,6 @@ class Player extends EventEmitter {
 
   stop() {
     this.position = 0;
-    this.isConnected = false;
     this.isPlaying = false;
     this.node.send({
       op: "stop",


### PR DESCRIPTION
Shouldn't we leave isConnected as it is when we just want to stop the player?