### PR TITLE
Fix for setVolume function and WebSocketClosedEvent in Player.js

### DIFF
--- a/dist/src/Player.js
+++ b/dist/src/Player.js
@@ -107,8 +107,9 @@ class Player extends events_1.EventEmitter {
         this.node.rest.updatePlayer({ guildId: this.guildId, data: { position } });
     }
     setVolume(volume) {
-        if (volume < 0 || volume > 1000)
-            throw new Error("[Poru Exception] Volume must be between 0 to 1000");
+        if (volume < 0 || volume > 100)
+            throw new Error("[Poru Exception] Volume must be between 0 to 100");
+        this.volume = volume
         this.node.rest.updatePlayer({ guildId: this.guildId, data: { volume } });
         return this;
     }
@@ -209,7 +210,7 @@ class Player extends events_1.EventEmitter {
                 this.stop();
                 break;
             }
-            case " WebSocketClosedEvent": {
+            case "WebSocketClosedEvent": {
                 if ([4015, 4009].includes(data.code)) {
                     this.send({
                         guild_id: data.guildId,


### PR DESCRIPTION
**1.** For the setVolume function, the range is supposed to be 0 to 100; not 1000. The line for setting the volume is missing.
`this.volume = volume`

**2.** For the event, there's an extra white space before the event name.
`case "WebSocketClosedEvent":`