### PR TITLE
Autoplay same music play in succession

### DIFF
--- a/src/Player/Player.ts
+++ b/src/Player/Player.ts
@@ -284,7 +284,7 @@ export class Player extends EventEmitter {
     this.poru.emit("playerDestroy", this);
     this.poru.players.delete(this.guildId);
   }
-  
+
   public restart() {
     if (!this.currentTrack.track && !this.queue.length) return;
     if (!this.currentTrack.track) return this.play();
@@ -342,9 +342,14 @@ export class Player extends EventEmitter {
         ["LOAD_FAILED", "NO_MATCHES"].includes(response.loadType)
       )
         return this.stop();
+
+      let tracks = response.tracks.filter((track) => track.info.identifier !== this.previousTrack.info.identifier && track.info.identifier !== this.currentTrack.info.identifier);
+
+      if (!tracks.length) return this.stop();
+
       let track =
-        response.tracks[
-        Math.floor(Math.random() * Math.floor(response.tracks.length))
+        tracks[
+        Math.floor(Math.random() * Math.floor(tracks.length))
         ];
       this.queue.push(track);
       this.play();

--- a/src/Player/Player.ts
+++ b/src/Player/Player.ts
@@ -343,13 +343,11 @@ export class Player extends EventEmitter {
       )
         return this.stop();
 
-      let tracks = response.tracks.filter((track) => track.info.identifier !== this.previousTrack.info.identifier && track.info.identifier !== this.currentTrack.info.identifier);
-
-      if (!tracks.length) return this.stop();
+      response.tracks.shift();
 
       let track =
-        tracks[
-        Math.floor(Math.random() * Math.floor(tracks.length))
+        response.tracks[
+        Math.floor(Math.random() * Math.floor(response.tracks.length))
         ];
       this.queue.push(track);
       this.play();


### PR DESCRIPTION
When playing music in autoplay mode, the check to see if the same music is being played is not carried out.

To correct this, simply remove the first element, which is the same as the previous music. 
```js
async autoplay(requester) {
    try {
      let data = `https://www.youtube.com/watch?v=${this.previousTrack.info.identifier || this.currentTrack.info.identifier
        }&list=RD${this.previousTrack.info.identifier || this.currentTrack.info.identifier
        }`;

      let response = await this.poru.resolve({
        query: data,
        requester,
        source: this.poru.options.defaultPlatform || "ytmsearch",
      });
      if (
        !response ||
        !response.tracks ||
        ["LOAD_FAILED", "NO_MATCHES"].includes(response.loadType)
      )
        return this.stop();

      response.tracks.shift(); // Remove music previously played

      let track =
        response.tracks[
        Math.floor(Math.random() * Math.floor(response.tracks.length))
        ];
      this.queue.push(track);
      this.play();

      return this;
    } catch (e) {
      return this.stop();
    }
  }
```