### PR TITLE
Update: Node, Connection, Poru

### DIFF
--- a/src/Node/Node.ts
+++ b/src/Node/Node.ts
@@ -120,7 +120,7 @@ export class Node {
      * @returns {void}
      */
     public async connect(): Promise<boolean> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             if (this.isConnected) return resolve(true);
             if (this.ws) this.ws.close();
             if (!this.poru.nodes.get(this.name)) {

--- a/src/Node/Node.ts
+++ b/src/Node/Node.ts
@@ -112,7 +112,7 @@ export class Node {
         this.attempt = 0;
         this.isConnected = false;
         this.stats = null;
-        this.clientName = options.clientName || config.clientName;
+        this.clientName = options.clientName || `${config.clientName}/${config.version}`;
     };
 
     /**

--- a/src/Player/Connection.ts
+++ b/src/Player/Connection.ts
@@ -3,7 +3,7 @@ import { Player } from "./Player";
 export interface IVoiceServer {
     token: string;
     sessionId: string;
-    endpoint: string;
+    endpoint?: string;
 };
 
 type TYear = `${number}${number}${number}${number}`;

--- a/src/Player/Player.ts
+++ b/src/Player/Player.ts
@@ -550,7 +550,7 @@ export class Player extends EventEmitter {
    * @returns {Promise<Response>} - A Promise that resolves to a Response object containing the resolved tracks.
    */
   public async resolve({ query, source, requester }: ResolveOptions): Promise<Response> {
-    const response = await this.node.rest.get<LoadTrackResponse>(`/v4/loadtracks?identifier=${encodeURIComponent((query.startsWith('https://') ? '' : source || 'ytsearch:') + query)}`)
+    const response = await this.node.rest.get<LoadTrackResponse>(`/v4/loadtracks?identifier=${encodeURIComponent((query.startsWith('https://') ? '' : `${source || 'ytsearch'}:`) + query)}`)
     return new Response(response, requester);
   };
 

--- a/src/Player/Player.ts
+++ b/src/Player/Player.ts
@@ -550,20 +550,8 @@ export class Player extends EventEmitter {
    * @returns {Promise<Response>} - A Promise that resolves to a Response object containing the resolved tracks.
    */
   public async resolve({ query, source, requester }: ResolveOptions): Promise<Response> {
-    const regex = /^https?:\/\//
-
-    if (regex.test(query)) {
-      const response = await this.node.rest.get<LoadTrackResponse>(
-        `/v4/loadtracks?identifier=${encodeURIComponent(query)}`
-      )
-      return new Response(response, requester)
-    } else {
-      const track = `${source || "ytsearch"}:${query}`
-      const response = await this.node.rest.get<LoadTrackResponse>(
-        `/v4/loadtracks?identifier=${encodeURIComponent(track)}`
-      )
-      return new Response(response, requester)
-    }
+    const response = await this.node.rest.get<LoadTrackResponse>(`/v4/loadtracks?identifier=${encodeURIComponent((query.startsWith('https://') ? '' : source || 'ytsearch:') + query)}`)
+    return new Response(response, requester);
   };
 
   /**

--- a/src/Poru.ts
+++ b/src/Poru.ts
@@ -512,7 +512,7 @@ export class Poru extends EventEmitter {
         if (!node) node = this.leastUsedNodes[0];
         if (!node) throw new Error("No nodes are available.");
         
-        const response = await node.rest.get<LoadTrackResponse>(`/v4/loadtracks?identifier=${encodeURIComponent((query.startsWith('https://') ? '' : source || 'ytsearch:') + query)}`)
+        const response = await node.rest.get<LoadTrackResponse>(`/v4/loadtracks?identifier=${encodeURIComponent((query.startsWith('https://') ? '' : `${source || 'ytsearch'}:`) + query)}`)
         return new Response(response, requester);
     }
 

--- a/src/Poru.ts
+++ b/src/Poru.ts
@@ -511,20 +511,9 @@ export class Poru extends EventEmitter {
 
         if (!node) node = this.leastUsedNodes[0];
         if (!node) throw new Error("No nodes are available.");
-        const regex = /^https?:\/\//;
-
-        if (regex.test(query)) {
-            let response = await node.rest.get<LoadTrackResponse>(
-                `/v4/loadtracks?identifier=${encodeURIComponent(query)}`
-            );
-            return new Response(response, requester);
-        } else {
-            let track = `${source || "ytsearch"}:${query}`;
-            let response = await node.rest.get<LoadTrackResponse>(
-                `/v4/loadtracks?identifier=${encodeURIComponent(track)}`
-            );
-            return new Response(response, requester);
-        }
+        
+        const response = await node.rest.get<LoadTrackResponse>(`/v4/loadtracks?identifier=${encodeURIComponent((query.startsWith('https://') ? '' : source || 'ytsearch:') + query)}`)
+        return new Response(response, requester);
     }
 
     /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
 export enum Config {
-    version = 4,
+    version = 5,
     clientName = "Poru"
 } 


### PR DESCRIPTION
# Node.ts:
    - Update `<Node>.connect` to be asynchronus for establishing a connection to the node.
    - Added to customize the Client Name to allow for other libraries besides Lavalink (*caugh caugh NodeLink caugh caugh*)
 
# Connection.ts:
    - Fix type `IVoiceServer` to make endpoint optional (refer to discord docs)

# Poru.ts:
    - Added 3 new interfaces to represent the Packets from discord (refer to discord docs)
    - Update types from `<Poru>.send` function
    - Update types from `<Poru>.packetUpdate` to use the new types

Have a nice day o/