### PR TITLE
Fix multiple bugs: escapeRegExp, variable shadowing, unhandled throws, race conditions

### DIFF
--- a/src/Node/Node.ts
+++ b/src/Node/Node.ts
@@ -269,9 +269,10 @@ export class Node {
     public async reconnect(): Promise<void> {
         this.reconnectAttempt = setTimeout(async () => {
             if (this.attempt > this.reconnectTries) {
-                throw new Error(
+                this.poru.emit("nodeError", this, new Error(
                     `[Poru Websocket] Unable to connect with ${this.options.name} node after ${this.reconnectTries} tries`
-                );
+                ));
+                return;
             }
 
             // Delete the ws instance
@@ -294,11 +295,11 @@ export class Node {
     public async disconnect(): Promise<void> {
         if (!this.isConnected) return;
 
-        this.poru.players.forEach(async (player) => {
+        for (const player of this.poru.players.values()) {
             if (player.node == this) {
                 await player.autoMoveNode();
             };
-        });
+        }
 
         this.ws?.close(1000, "destroy");
         this.ws?.removeAllListeners();
@@ -386,7 +387,11 @@ export class Node {
             this.isConnected = true;
             this.poru.emit("debug", this.options.name, `[Web Socket] Connection ready ${this.socketURL}`);
 
-            if (this.autoResume) this.poru.players.forEach(async (player) => player.node === this ? await player.restart() : null);
+            if (this.autoResume) {
+                for (const player of this.poru.players.values()) {
+                    if (player.node === this) await player.restart();
+                }
+            }
         } catch (error) {
             this.poru.emit("debug", `[Web Socket] Error while opening the connection with the node ${this.options.name}.`, error)
         };

--- a/src/Player/Connection.ts
+++ b/src/Player/Connection.ts
@@ -55,6 +55,7 @@ export class Connection {
     public voice: IVoiceServer | PartialNull<IVoiceServer>;
     public self_mute: boolean;
     public self_deaf: boolean;
+    private serverUpdateTimeout: NodeJS.Timeout | null;
 
     /**
      * The connection class
@@ -72,6 +73,7 @@ export class Connection {
         };
         this.self_mute = false;
         this.self_deaf = false;
+        this.serverUpdateTimeout = null;
     }
 
     /**
@@ -90,8 +92,10 @@ export class Connection {
             guildId: this.player.guildId,
             data: { voice: this.voice },
         });
-        setTimeout(async () => {
+        if (this.serverUpdateTimeout) clearTimeout(this.serverUpdateTimeout);
+        this.serverUpdateTimeout = setTimeout(async () => {
             if (!this.player.poru.players.has(this.player.guildId)) return;
+            if (this.player.isPaused) return;
             await this.player.node.rest.updatePlayer({
                 guildId: this.player.guildId,
                 data: { paused: false },

--- a/src/Player/Player.ts
+++ b/src/Player/Player.ts
@@ -12,7 +12,7 @@ type Loop = "NONE" | "TRACK" | "QUEUE"
 
 const escapeRegExp = (str: string) => {
   try {
-    str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
   } catch { }
 }
 
@@ -230,9 +230,9 @@ export class Player extends EventEmitter {
     }
     if (track.info.length) {
       const sameDuration = result.tracks.find(
-        (track) =>
-          track.info.length >= (track.info.length ? track.info.length : 0) - 2000 &&
-          track.info.length <= (track.info.length ? track.info.length : 0) + 2000
+        (resultTrack) =>
+          resultTrack.info.length >= (track.info.length ? track.info.length : 0) - 2000 &&
+          resultTrack.info.length <= (track.info.length ? track.info.length : 0) + 2000
       )
       if (sameDuration) {
         track.info.identifier = sameDuration.info.identifier;
@@ -298,7 +298,7 @@ export class Player extends EventEmitter {
 
     if (!encodedTrack && !this.currentTrack) throw new Error("[Poru Exception] A track must be playing right now or be supplied.");
 
-    encodedTrack = this.currentTrack?.track;
+    if (!encodedTrack) encodedTrack = this.currentTrack?.track;
 
     return await this.node.rest.get<NodeLinkGetLyrics>(`/v4/lyrics?track=${encodeURIComponent(encodedTrack ?? "")}`)
   };
@@ -772,9 +772,10 @@ export class Player extends EventEmitter {
   private async voiceReceiverReconnect(): Promise<void> {
     this.voiceReceiverReconnectTimeout = setTimeout(async () => {
       if (this.voiceReceiverAttempt > this.voiceReceiverReconnectTries) {
-        throw new Error(
+        this.poru.emit("nodeError", this.node, new Error(
           `[Poru Voice Receiver Websocket] Unable to connect with ${this.node.name} node to the voice Receiver Websocket after ${this.voiceReceiverReconnectTries} tries`
-        );
+        ));
+        return;
       }
       // Delete the ws instance
       this.isConnected = false;

--- a/src/Poru.ts
+++ b/src/Poru.ts
@@ -347,7 +347,9 @@ export class Poru extends EventEmitter {
     public async init() {
         if (this.isActivated) return this;
         this.userId = this.client.user.id;
-        this._nodes.forEach(async (node) => await this.addNode(node));
+        for (const node of this._nodes) {
+            await this.addNode(node);
+        }
         this.isActivated = true;
 
         if (this.options.plugins) {


### PR DESCRIPTION
## Summary

- **Fix escapeRegExp missing return**: `String.replace()` returns a new string but the return value was discarded, making the function always return `undefined`. Added `return` before the call.
- **Fix variable shadowing in duration comparison**: The `.find()` callback parameter `track` shadowed the outer `track`, causing each candidate to compare its duration against itself (always true). Renamed to `resultTrack`.
- **Fix throw inside setTimeout async crashes process**: In `Node.reconnect()` and `Player.voiceReceiverReconnect()`, throwing inside a `setTimeout` async callback produces an unhandled promise rejection that crashes Node.js v15+. Replaced with `this.poru.emit("nodeError", ...)` and early return.
- **Fix forEach(async ...) race conditions**: `forEach` does not await async callbacks, so operations ran concurrently in an uncontrolled way. Replaced with `for...of` loops with `await` in `Node.disconnect()`, `Node.open()`, and `Poru.init()`.
- **Fix getLyrics ignoring encodedTrack parameter**: The parameter was unconditionally overwritten by `this.currentTrack?.track`. Changed to only use the fallback when no parameter is provided.
- **Fix auto-unpause ignoring intentional pause state**: `setServersUpdate` unconditionally sent `paused: false` after 1 second, overriding user-initiated pauses. Added `isPaused` check and stored the timeout reference for proper cleanup on rapid reconnections.

## Test plan

- [ ] Verify `escapeRegExp` returns the escaped string (track resolution matching works)
- [ ] Verify `resolveTrack` duration comparison matches against the original track, not self
- [ ] Verify reconnection failures emit `nodeError` event instead of crashing the process
- [ ] Verify nodes are added sequentially during `init()` and players are moved sequentially during `disconnect()`
- [ ] Verify `getLyrics("custom-encoded-track")` uses the provided track instead of the current one
- [ ] Verify that pausing a player is not overridden by voice server updates
- [ ] Run `npx tsc --noEmit` to confirm no type errors